### PR TITLE
Added Pagination

### DIFF
--- a/src/main/java/com/fredmaina/chatapp/core/Controllers/ChatController.java
+++ b/src/main/java/com/fredmaina/chatapp/core/Controllers/ChatController.java
@@ -6,6 +6,7 @@ import com.fredmaina.chatapp.Auth.Repositories.UserRepository;
 import com.fredmaina.chatapp.Auth.services.JWTService;
 import com.fredmaina.chatapp.core.DTOs.ChatMessageDto;
 import com.fredmaina.chatapp.core.DTOs.ChatSessionDto;
+import com.fredmaina.chatapp.core.DTOs.PaginationDto;
 import com.fredmaina.chatapp.core.Repositories.ChatMessageRepository;
 import com.fredmaina.chatapp.core.Services.ChatService;
 import com.fredmaina.chatapp.core.models.ChatMessage;
@@ -63,12 +64,21 @@ public class ChatController {
     @GetMapping("/chat/session_history")
     public ResponseEntity<?> getAnonChatHistory(
             @RequestParam String sessionId,
-            @RequestParam String recipient // This is the username of the dashboard owner
+            @RequestParam String recipient, // This is the username of the dashboard owner
+             @RequestParam(defaultValue = "0") int page,
+    @RequestParam(defaultValue = "50") int size
     ) {
-        ;
-        List<ChatMessageDto> messages = chatService.getChatHistoryForAnonymous(sessionId, recipient);
+        PaginationDto chatPage =
+                chatService.getChatHistoryForAnonymous(sessionId, recipient, page, size);
 
-        return ResponseEntity.ok(Map.of("success", true, "messages", messages));
+        return ResponseEntity.ok(Map.of(
+                "success", true,
+                "page", chatPage.getPage(),
+                "size", chatPage.getSize(),
+                "totalPages", chatPage.getTotalPages(),
+                "hasNextPage", chatPage.isHasNextPage(),
+                "messages", chatPage.getMessages()
+        ));
     }
 
     @DeleteMapping("/chat/{anonSessionId}")

--- a/src/main/java/com/fredmaina/chatapp/core/DTOs/PaginationDto.java
+++ b/src/main/java/com/fredmaina/chatapp/core/DTOs/PaginationDto.java
@@ -1,0 +1,19 @@
+package com.fredmaina.chatapp.core.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PaginationDto {
+
+        private List<ChatMessageDto> messages;
+        private int page;
+        private int size;
+        private int totalPages;
+        private boolean hasNextPage;
+    }
+
+

--- a/src/main/java/com/fredmaina/chatapp/core/Repositories/ChatMessageRepository.java
+++ b/src/main/java/com/fredmaina/chatapp/core/Repositories/ChatMessageRepository.java
@@ -2,6 +2,8 @@ package com.fredmaina.chatapp.core.Repositories;
 
 import com.fredmaina.chatapp.Auth.Models.User;
 import com.fredmaina.chatapp.core.models.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -24,8 +26,9 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> 
             "OR " +
             "(m.toSessionId = :sessionId AND m.fromUser.id = :recipientId) " +
             "ORDER BY m.timestamp")
-    List<ChatMessage> findFullChatHistory(@Param("sessionId") String sessionId,
-                                          @Param("recipientId") UUID recipientId);
+    Page<ChatMessage> findFullChatHistory(@Param("sessionId") String sessionId,
+                                          @Param("recipientId") UUID recipientId
+                                           , Pageable pageable);
 
 
 


### PR DESCRIPTION
✅ Backend Pagination Added

Updated ChatMessageRepository.findFullChatHistory to accept Pageable instead of returning a full list.

Modified ChatService.getChatHistoryForAnonymous to:

Accept page and size

Use PageRequest.of(page, size, Sort.by("timestamp").descending())

Return a new ChatHistoryPageDto that includes:

paginated messages

page number

size

total pages

hasNextPage flag

✅ New DTO Added

Created PaginationDto.ChatHistoryPageDto containing:

List<ChatMessageDto> messages

int page

int size

int totalPages

boolean hasNextPage

✅ Controller Updated