### PR TITLE
Add EC2 Nginx HTTPS deployment setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 env:
-  IMAGE_NAME: fredmaina/chatapp
+  APP_NAME: chatapp
+  APP_DIR: /home/${{ secrets.EC2_USER }}/chatapp
+  APP_PORT: ${{ secrets.APP_PORT || '8080' }}
 
 jobs:
   build-and-deploy:
@@ -14,49 +17,219 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 21
+          cache: maven
 
-      - name: Set image tag to Git commit SHA
-        run: echo "IMAGE_TAG=${GITHUB_SHA}" >> $GITHUB_ENV
+      - name: Build application
+        run: ./mvnw clean package -DskipTests
 
-      - name: Build with Maven (skip tests)
-        run: mvn clean package -DskipTests
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and push Docker image with Git SHA tag
+      - name: Prepare deployment bundle
         run: |
-          docker build -t $IMAGE_NAME:$IMAGE_TAG .
-          docker push $IMAGE_NAME:$IMAGE_TAG
+          mkdir -p deploy
+          cp target/*.jar deploy/app.jar
+          cp scripts/setup_nginx.sh deploy/setup_nginx.sh
+          cp scripts/setup_postgres.sh deploy/setup_postgres.sh
+          cp scripts/setup_redis.sh deploy/setup_redis.sh
+          cp scripts/check_app_health.sh deploy/check_app_health.sh
 
-      - name: Deploy to EC2 and restart containers
-        uses: appleboy/ssh-action@v1.0.3
+      - name: Copy deployment bundle to EC2
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          port: 22
+          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          source: deploy/*
+          target: ${{ env.APP_DIR }}
+          strip_components: 1
+
+      - name: Deploy application and configure Nginx
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          APP_DIR: ${{ env.APP_DIR }}
+          APP_NAME: ${{ env.APP_NAME }}
+          APP_PORT: ${{ env.APP_PORT }}
+          APP_CONFIG_DIR: /opt/myapp
+          APP_ENV_FILE: /opt/myapp/.env
+          REDIS_ENV_FILE: /opt/myapp/redis.env
+          DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
+          CERTBOT_EMAIL: ${{ secrets.CERTBOT_EMAIL }}
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          REDIS_HOST: ${{ secrets.REDIS_HOST }}
+          REDIS_PORT: ${{ secrets.REDIS_PORT }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          envs: APP_DIR,APP_NAME,APP_PORT,APP_CONFIG_DIR,APP_ENV_FILE,REDIS_ENV_FILE,DOMAIN_NAME,CERTBOT_EMAIL,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,REDIS_HOST,REDIS_PORT,REDIS_PASSWORD
+          script_stop: true
           script: |
-            echo "📁 Moving into project directory"
-            cd /home/ec2-user/chatapp
+            set -euo pipefail
 
-            echo "🔁 Updating image tag in docker-compose.yaml"
-            sed -i 's|image: fredmaina/chatapp:.*|image: fredmaina/chatapp:${{ github.sha }}|' docker-compose.yaml
+            mkdir -p "${APP_DIR}"
+            chmod +x "${APP_DIR}/setup_nginx.sh" "${APP_DIR}/setup_postgres.sh" "${APP_DIR}/setup_redis.sh" "${APP_DIR}/check_app_health.sh"
+            REMOTE_USER="$(id -un)"
+            APP_SECRETS_FILE="${APP_DIR}/.env"
 
-            echo "📦 Pulling new Docker image"
-            docker pull fredmaina/chatapp:${{ github.sha }}
+            if [[ "${DOMAIN_NAME}" == http://* || "${DOMAIN_NAME}" == https://* || "${DOMAIN_NAME}" == */* ]]; then
+              echo "DOMAIN_NAME must be a hostname only, for example chat.fredmaina.com. Do not include http:// or https://."
+              exit 1
+            fi
 
-            echo "🚀 Restarting containers using existing .env file"
-            docker-compose --env-file .env up -d --remove-orphans
+            env_file_has_value() {
+              local file_path="$1"
+              local key="$2"
 
-            echo "✅ Deployment complete"
+              sudo awk -F= -v key="${key}" '
+                $0 ~ "^[[:space:]]*(export[[:space:]]+)?" key "[[:space:]]*=" {
+                  sub(/^[^=]*=/, "")
+                  gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+                  gsub(/^'\''|'\''$/, "")
+                  gsub(/^"|"$/, "")
+                  if (length($0) > 0) {
+                    found = 1
+                  }
+                }
+                END { exit found ? 0 : 1 }
+              ' "${file_path}"
+            }
+
+            require_env_keys() {
+              local file_path="$1"
+              shift
+              local missing_keys=()
+              local key
+
+              if ! sudo test -f "${file_path}"; then
+                echo "Missing required environment file: ${file_path}"
+                return 1
+              fi
+
+              for key in "$@"; do
+                if ! env_file_has_value "${file_path}" "${key}"; then
+                  missing_keys+=("${key}")
+                fi
+              done
+
+              if [[ "${#missing_keys[@]}" -gt 0 ]]; then
+                echo "Missing required environment variables in ${file_path}: ${missing_keys[*]}"
+                return 1
+              fi
+
+              echo "Validated required environment variables in ${file_path}."
+            }
+
+            if ! dpkg-query -W -f='${Status}' openjdk-21-jre-headless 2>/dev/null | grep -q "install ok installed"; then
+              sudo apt-get update
+              sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-21-jre-headless
+            fi
+
+            if [[ -n "${DB_HOST:-}" && -n "${DB_PORT:-}" && -n "${DB_NAME:-}" && -n "${DB_USERNAME:-}" && -n "${DB_PASSWORD:-}" ]]; then
+              sudo mkdir -p "${APP_CONFIG_DIR}"
+              sudo tee "${APP_ENV_FILE}" >/dev/null <<DBENV
+            DB_HOST=${DB_HOST}
+            DB_PORT=${DB_PORT}
+            DB_NAME=${DB_NAME}
+            DB_USERNAME=${DB_USERNAME}
+            DB_PASSWORD=${DB_PASSWORD}
+            SPRING_DATASOURCE_URL=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+            SPRING_DATASOURCE_USERNAME=${DB_USERNAME}
+            SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
+            DBENV
+              sudo chmod 600 "${APP_ENV_FILE}"
+              echo "Using external PostgreSQL configuration from GitHub Secrets."
+            else
+              env -u DB_PASSWORD \
+                APP_CONFIG_DIR="${APP_CONFIG_DIR}" \
+                APP_ENV_FILE="${APP_ENV_FILE}" \
+                DB_HOST="127.0.0.1" \
+                DB_PORT="5432" \
+                DB_NAME="myapp" \
+                DB_USERNAME="myapp_user" \
+                bash "${APP_DIR}/setup_postgres.sh"
+            fi
+
+            if [[ -n "${REDIS_HOST:-}" && -n "${REDIS_PORT:-}" && -n "${REDIS_PASSWORD:-}" ]]; then
+              sudo mkdir -p "${APP_CONFIG_DIR}"
+              sudo tee "${REDIS_ENV_FILE}" >/dev/null <<REDISENV
+            REDIS_HOST=${REDIS_HOST}
+            REDIS_PORT=${REDIS_PORT}
+            REDIS_PASSWORD=${REDIS_PASSWORD}
+            REDISENV
+              sudo chmod 600 "${REDIS_ENV_FILE}"
+              echo "Using external Redis configuration from GitHub Secrets."
+            else
+              env -u REDIS_PASSWORD \
+                APP_CONFIG_DIR="${APP_CONFIG_DIR}" \
+                REDIS_ENV_FILE="${REDIS_ENV_FILE}" \
+                REDIS_HOST="127.0.0.1" \
+                REDIS_PORT="6379" \
+                bash "${APP_DIR}/setup_redis.sh"
+            fi
+
+            require_env_keys "${APP_SECRETS_FILE}" \
+              JWT_SECRET \
+              GOOGLE_CLIENT_ID \
+              GOOGLE_SECRET_ID \
+              GOOGLE_REDIRECT_URI
+
+            require_env_keys "${APP_ENV_FILE}" \
+              SPRING_DATASOURCE_URL \
+              SPRING_DATASOURCE_USERNAME \
+              SPRING_DATASOURCE_PASSWORD
+
+            require_env_keys "${REDIS_ENV_FILE}" \
+              REDIS_HOST \
+              REDIS_PORT \
+              REDIS_PASSWORD
+
+            sudo tee /etc/systemd/system/${APP_NAME}.service >/dev/null <<SERVICE
+            [Unit]
+            Description=ChatApp Spring Boot service
+            After=network.target docker.service
+            Wants=docker.service
+
+            [Service]
+            Type=simple
+            WorkingDirectory=${APP_DIR}
+            Environment=SERVER_PORT=${APP_PORT}
+            EnvironmentFile=-${APP_DIR}/.env
+            EnvironmentFile=${APP_ENV_FILE}
+            EnvironmentFile=${REDIS_ENV_FILE}
+            ExecStart=/usr/bin/java -jar ${APP_DIR}/app.jar
+            Restart=always
+            RestartSec=10
+            User=${REMOTE_USER}
+
+            [Install]
+            WantedBy=multi-user.target
+            SERVICE
+
+            sudo systemctl daemon-reload
+            sudo systemctl enable ${APP_NAME}
+            if ! sudo systemctl restart ${APP_NAME}; then
+              echo "Application service failed to restart. SSH into the server and run: sudo journalctl -u ${APP_NAME} -n 100 --no-pager"
+              exit 1
+            fi
+
+            sleep 5
+            if ! sudo systemctl is-active --quiet ${APP_NAME}; then
+              echo "Application service is not active after restart. SSH into the server and run: sudo journalctl -u ${APP_NAME} -n 100 --no-pager"
+              exit 1
+            fi
+
+            echo "Application service restarted and is active."
+            bash "${APP_DIR}/check_app_health.sh" "http://localhost:${APP_PORT}/actuator/health"
+
+            DOMAIN_NAME="${DOMAIN_NAME}" CERTBOT_EMAIL="${CERTBOT_EMAIL}" APP_PORT="${APP_PORT}" bash "${APP_DIR}/setup_nginx.sh"
+            bash "${APP_DIR}/check_app_health.sh" "https://${DOMAIN_NAME}/actuator/health"

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ The primary configuration is in `src/main/resources/application.properties`. Set
     ```
 The application typically starts on `http://localhost:8080`.
 
+## Production Deployment
+
+For Ubuntu EC2 deployment with Nginx, HTTPS, Certbot, and GitHub Actions, see [docs/deployment.md](docs/deployment.md).
+
 ---
 
 ## API Endpoints
@@ -246,4 +250,3 @@ Base Path: `/api`
 ## Database Migrations
 
 Managed by Flyway. Scripts are in `src/main/resources/db/migration`.
-

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,524 @@
+# Deployment: EC2, Nginx, and HTTPS
+
+This project can be deployed to an Ubuntu-based EC2 instance with the Spring Boot app listening locally on `localhost:8080` and Nginx serving public HTTPS traffic.
+
+## How It Works
+
+The deployment has three moving parts:
+
+- GitHub Actions builds the Spring Boot jar, copies it to the EC2 instance, creates or updates a systemd service, and restarts the app.
+- `scripts/setup_nginx.sh` installs and configures Nginx, obtains or renews a Let's Encrypt certificate with Certbot, and reverse-proxies public traffic to `http://localhost:8080`.
+- `scripts/setup_postgres.sh` creates a local PostgreSQL Docker container only when external database secrets are not provided.
+- `scripts/setup_redis.sh` creates a local Redis Docker container only when external Redis secrets are not provided.
+
+The public request flow is:
+
+```text
+Browser -> HTTPS Nginx -> http://localhost:8080 -> Spring Boot app
+```
+
+HTTP requests are redirected to HTTPS after the certificate is available.
+
+Requests sent to the raw server IP address or an unexpected host name are rejected by the managed Nginx default server. Only requests for `DOMAIN_NAME` are redirected or proxied.
+
+## Required GitHub Secrets
+
+Configure these secrets in the GitHub repository before using the deployment workflow:
+
+| Secret | Purpose |
+| --- | --- |
+| `EC2_HOST` | Public DNS name or IP address of the EC2 instance. |
+| `EC2_USER` | SSH username on the Ubuntu instance, for example `ubuntu`. |
+| `EC2_SSH_PRIVATE_KEY` | Private SSH key that can log in as `EC2_USER`. Do not commit this key. |
+| `DOMAIN_NAME` | Public domain that points to the EC2 instance, for example `api.example.com`. Use the hostname only; do not include `http://` or `https://`. |
+| `CERTBOT_EMAIL` | Email used by Certbot for Let's Encrypt registration and renewal notices. |
+| `APP_PORT` | Optional local app port. Use `8080`; if omitted in the workflow, it defaults to `8080`. |
+
+Optional database secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `DB_HOST` | External PostgreSQL host, such as an RDS endpoint. |
+| `DB_PORT` | External PostgreSQL port, usually `5432`. |
+| `DB_NAME` | External PostgreSQL database name. |
+| `DB_USERNAME` | External PostgreSQL username. |
+| `DB_PASSWORD` | External PostgreSQL password. |
+
+If all five database secrets are provided, deployment uses the external database and does not create a local PostgreSQL container. If any of them are missing, deployment creates or reuses a local PostgreSQL Docker container.
+
+Optional Redis secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `REDIS_HOST` | External Redis host. |
+| `REDIS_PORT` | External Redis port, usually `6379`. |
+| `REDIS_PASSWORD` | External Redis password. |
+
+If all three Redis secrets are provided, deployment uses the external Redis instance and does not create a local Redis container. If any of them are missing, deployment creates or reuses a local Redis Docker container.
+
+The application itself also needs its normal runtime configuration on the EC2 host. The systemd service loads optional application environment variables from:
+
+```bash
+/home/<EC2_USER>/chatapp/.env
+```
+
+Add required non-database application secrets there:
+
+```bash
+JWT_SECRET=...
+GOOGLE_CLIENT_ID=...
+GOOGLE_SECRET_ID=...
+GOOGLE_REDIRECT_URI=...
+```
+
+Deployment validates this file before restarting the app. If any required key is missing or empty, the workflow fails before starting the service and prints only the missing key names, not secret values.
+
+Do not commit private keys, database passwords, JWT secrets, OAuth secrets, or Redis passwords.
+
+Database connection values are written by deployment to:
+
+```bash
+/opt/myapp/.env
+```
+
+The file is created with `600` permissions and contains both generic database variables and Spring Boot datasource variables:
+
+```bash
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_NAME=myapp
+DB_USERNAME=myapp_user
+DB_PASSWORD=<generated-secure-password>
+SPRING_DATASOURCE_URL=jdbc:postgresql://127.0.0.1:5432/myapp
+SPRING_DATASOURCE_USERNAME=myapp_user
+SPRING_DATASOURCE_PASSWORD=<generated-secure-password>
+```
+
+Do not print this file in CI logs. To confirm the database file exists without showing values, list only the keys:
+
+```bash
+sudo awk -F= '/^[A-Z_]+=/{print $1}' /opt/myapp/.env
+```
+
+Redis connection values are written by deployment to:
+
+```bash
+/opt/myapp/redis.env
+```
+
+For local Redis, the file contains:
+
+```bash
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+REDIS_PASSWORD=<generated-secure-password>
+```
+
+Check only the keys without printing values:
+
+```bash
+sudo awk -F= '/^[A-Z_]+=/{print $1}' /opt/myapp/redis.env
+```
+
+## Manual Nginx Setup
+
+SSH into the EC2 instance, make sure this repository or the deployment bundle is present, and run:
+
+```bash
+DOMAIN_NAME=example.com CERTBOT_EMAIL=admin@example.com APP_PORT=8080 bash scripts/setup_nginx.sh
+```
+
+`DOMAIN_NAME` and `CERTBOT_EMAIL` are required. `APP_PORT` defaults to `8080`.
+
+Before running the script, confirm:
+
+- The EC2 security group allows inbound TCP `80` and `443`.
+- The domain has an `A` or `CNAME` record pointing to the EC2 instance.
+- The app is running locally on the EC2 instance.
+
+Use `DOMAIN_NAME=chat.fredmaina.com`, not `DOMAIN_NAME=https://chat.fredmaina.com`.
+
+Check the local app:
+
+```bash
+curl http://localhost:8080
+```
+
+Check local app, PostgreSQL, and Redis health:
+
+```bash
+bash scripts/check_app_health.sh http://localhost:8080/actuator/health
+```
+
+Test the public HTTPS endpoint:
+
+```bash
+curl https://your-domain.com
+```
+
+Check public HTTPS app, PostgreSQL, and Redis health:
+
+```bash
+bash scripts/check_app_health.sh https://your-domain.com/actuator/health
+```
+
+## Database Modes
+
+The deployment supports two database modes.
+
+External database mode is used when these GitHub Secrets are all present:
+
+```text
+DB_HOST
+DB_PORT
+DB_NAME
+DB_USERNAME
+DB_PASSWORD
+```
+
+In this mode, GitHub Actions writes those values to `/opt/myapp/.env`, derives the Spring Boot datasource settings, and skips local PostgreSQL container creation.
+
+Local PostgreSQL mode is used when any required database secret is missing. In this mode, `scripts/setup_postgres.sh`:
+
+- Installs Docker if it is missing.
+- Creates the Docker volume `myapp-postgres-data` if it does not exist.
+- Creates the Docker container `myapp-postgres` if it does not exist.
+- Binds PostgreSQL to `127.0.0.1:5432`.
+- Generates a secure password with `openssl rand -hex 32` when no existing local password is present.
+- Stores local DB config in `/opt/myapp/.env`.
+- Starts the existing container if it is stopped.
+
+The local PostgreSQL volume preserves database data across deployments and container restarts.
+
+Do not delete the PostgreSQL Docker volume unless you intentionally want to delete the database data.
+
+Run the local PostgreSQL setup manually:
+
+```bash
+bash scripts/setup_postgres.sh
+```
+
+## Redis Modes
+
+The deployment supports two Redis modes.
+
+External Redis mode is used when these GitHub Secrets are all present:
+
+```text
+REDIS_HOST
+REDIS_PORT
+REDIS_PASSWORD
+```
+
+In this mode, GitHub Actions writes those values to `/opt/myapp/redis.env` and skips local Redis container creation.
+
+Local Redis mode is used when any required Redis secret is missing. In this mode, `scripts/setup_redis.sh`:
+
+- Installs Docker if it is missing.
+- Creates the Docker volume `myapp-redis-data` if it does not exist.
+- Creates the Docker container `myapp-redis` if it does not exist.
+- Binds Redis to `127.0.0.1:6379`.
+- Generates a secure password with `openssl rand -hex 32` when no existing local password is present.
+- Stores local Redis config in `/opt/myapp/redis.env`.
+- Starts the existing container if it is stopped.
+
+Run the local Redis setup manually:
+
+```bash
+bash scripts/setup_redis.sh
+```
+
+## Idempotency
+
+The Nginx setup script is safe to run during every deployment:
+
+- It checks whether `nginx`, `certbot`, and `python3-certbot-nginx` are already installed before installing packages.
+- It writes one managed site config at `/etc/nginx/sites-available/chatapp.conf`.
+- It enables the site with a single symlink at `/etc/nginx/sites-enabled/chatapp.conf`.
+- It compares the desired Nginx config with the existing file and only rewrites it when content changed.
+- It checks whether the certificate already exists before requesting one.
+- It uses `certbot renew --quiet`, which only renews certificates that are due.
+- It always runs `sudo nginx -t` before reloading or restarting Nginx.
+- If the app's Nginx config is missing, outdated, or manually changed, the script replaces it with the expected config.
+- It disables the stock Ubuntu Nginx default site symlink so the managed default server handles raw-IP requests.
+- It rejects raw-IP and unexpected-host requests with Nginx `444` responses.
+
+If another unrelated Nginx config on the server is broken, `sudo nginx -t` will fail and the script will not reload Nginx. Fix the broken Nginx config and rerun the script.
+
+The PostgreSQL setup script is also safe to run during every deployment:
+
+- It installs Docker only when Docker is missing.
+- It creates the named Docker volume only when missing.
+- It creates the named PostgreSQL container only when missing.
+- It starts the existing PostgreSQL container if it is stopped.
+- It reuses existing credentials from `/opt/myapp/.env`.
+- It does not regenerate the local DB password when one already exists.
+- It does not delete or recreate the Docker volume.
+
+The Redis setup script is also safe to run during every deployment:
+
+- It installs Docker only when Docker is missing.
+- It creates the named Docker volume only when missing.
+- It creates the named Redis container only when missing.
+- It starts the existing Redis container if it is stopped.
+- It reuses existing credentials from `/opt/myapp/redis.env`.
+- It does not regenerate the local Redis password when one already exists.
+- It binds Redis to `127.0.0.1`, not a public interface.
+
+Flyway migrations run automatically when the Spring Boot app starts. Hibernate schema validation is enabled with `spring.jpa.hibernate.ddl-auto=validate`, so the app fails startup if the schema created by migrations no longer matches the entity models.
+
+## HTTPS and Certbot
+
+On a fresh host, the script first writes a temporary HTTP-only Nginx config so Nginx can start before any certificate files exist. It then requests a Let's Encrypt certificate using Certbot's Nginx plugin.
+
+After the certificate exists, the script writes the final config:
+
+- Port `80` redirects to HTTPS.
+- Raw-IP or unexpected-host requests are rejected by the default server.
+- Port `443` uses the Let's Encrypt certificate.
+- Requests are proxied to `http://localhost:8080`.
+- Standard reverse proxy headers are sent to the app:
+
+```nginx
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+```
+
+## GitHub Actions Deployment
+
+The workflow at `.github/workflows/deploy.yml` runs on pushes to `main` and can also be started manually with `workflow_dispatch`.
+
+It performs these steps:
+
+1. Checks out the repository.
+2. Sets up Java 21.
+3. Builds the Spring Boot jar with Maven.
+4. Copies `app.jar` and `setup_nginx.sh` to `/home/<EC2_USER>/chatapp` on the EC2 instance.
+5. Copies `setup_postgres.sh` to the EC2 instance.
+6. Installs the Java 21 runtime on the EC2 instance if it is missing.
+7. Uses external DB secrets when all five database secrets exist.
+8. Otherwise creates or reuses a local PostgreSQL Docker container.
+9. Uses external Redis secrets when all three Redis secrets exist.
+10. Otherwise creates or reuses a local Redis Docker container.
+11. Validates the required server-side app environment keys without printing values.
+12. Validates the required datasource and Redis environment keys without printing values.
+13. Creates or updates a systemd service named `chatapp`.
+14. Restarts the app with `SERVER_PORT=8080`.
+15. Checks that the service is active without printing service logs.
+16. Runs the local actuator health check and requires app, PostgreSQL, and Redis health to be `UP`.
+17. Runs the idempotent Nginx and HTTPS setup script.
+18. Runs the public HTTPS actuator health check and requires app, PostgreSQL, and Redis health to be `UP`.
+
+The workflow assumes the EC2 user can run `sudo` for service and Nginx management.
+
+The workflow intentionally does not print systemd logs or environment file contents. If startup fails, it reports the failure and tells you which server-side command to run manually over SSH.
+
+## Troubleshooting
+
+Validate Nginx configuration:
+
+```bash
+sudo nginx -t
+```
+
+Check Nginx status:
+
+```bash
+sudo systemctl status nginx
+```
+
+Reload Nginx after a valid config change:
+
+```bash
+sudo systemctl reload nginx
+```
+
+List Certbot certificates:
+
+```bash
+sudo certbot certificates
+```
+
+Inspect Nginx logs:
+
+```bash
+sudo journalctl -u nginx
+```
+
+Check the app service:
+
+```bash
+sudo systemctl status chatapp
+sudo journalctl -u chatapp -f
+```
+
+Check the app locally:
+
+```bash
+curl http://localhost:8080
+```
+
+Check HTTPS publicly:
+
+```bash
+curl https://your-domain.com
+```
+
+Check actuator health publicly:
+
+```bash
+curl https://your-domain.com/actuator/health
+```
+
+Check that raw-IP HTTP requests are rejected:
+
+```bash
+curl -I http://<ec2-public-ip>
+```
+
+Check PostgreSQL containers and logs:
+
+```bash
+docker ps
+docker ps -a
+docker logs myapp-postgres
+docker volume ls
+docker inspect myapp-postgres
+sudo awk -F= '/^[A-Z_]+=/{print $1}' /opt/myapp/.env
+```
+
+Connect to the local PostgreSQL container:
+
+```bash
+docker exec -it myapp-postgres psql -U myapp_user -d myapp
+```
+
+Safely restart the local PostgreSQL container:
+
+```bash
+docker restart myapp-postgres
+```
+
+Check Redis containers and logs:
+
+```bash
+docker ps
+docker ps -a
+docker logs myapp-redis
+docker volume ls
+docker inspect myapp-redis
+sudo awk -F= '/^[A-Z_]+=/{print $1}' /opt/myapp/redis.env
+```
+
+Connect to the local Redis container:
+
+```bash
+docker exec -it myapp-redis redis-cli -a "$(sudo awk -F= '$1 == "REDIS_PASSWORD" {print $2}' /opt/myapp/redis.env)" ping
+```
+
+Safely restart the local Redis container:
+
+```bash
+docker restart myapp-redis
+```
+
+Common issues:
+
+- `nginx -t` fails: inspect the error output and fix any invalid Nginx config before reloading.
+- `DOMAIN_NAME` validation fails: store only `chat.fredmaina.com`, not `https://chat.fredmaina.com`.
+- Certbot cannot issue a certificate: confirm DNS points to the EC2 instance and ports `80` and `443` are open.
+- Health check fails for `db`: check database credentials, local Postgres container state, and Flyway migration errors in `sudo journalctl -u chatapp -n 100 --no-pager`.
+- Health check fails for `redis`: check Redis credentials and local Redis container state.
+- HTTPS works but the app returns errors: check `sudo journalctl -u chatapp -n 100 --no-pager` and confirm the `.env` files contain the required Spring, database, Redis, JWT, and OAuth settings.
+- Public requests time out: verify the EC2 security group, instance firewall, Nginx status, and DNS records.
+- PostgreSQL container is not running: check `docker ps -a`, `docker logs myapp-postgres`, and `sudo systemctl status docker`.
+- Local DB data seems missing: verify the container still uses the `myapp-postgres-data` volume and confirm the volume was not deleted.
+- Redis container is not running: check `docker ps -a`, `docker logs myapp-redis`, and `sudo systemctl status docker`.
+
+## Assumptions
+
+- The EC2 instance runs Ubuntu.
+- The app listens locally on port `8080`.
+- The deployment user has passwordless `sudo`.
+- Runtime application secrets are stored on the EC2 instance, not in the repository.
+
+## Secrets Checklist
+
+Add these GitHub repository secrets:
+
+```text
+EC2_HOST
+EC2_USER
+EC2_SSH_PRIVATE_KEY
+DOMAIN_NAME
+CERTBOT_EMAIL
+```
+
+Optional GitHub repository secrets:
+
+```text
+APP_PORT
+DB_HOST
+DB_PORT
+DB_NAME
+DB_USERNAME
+DB_PASSWORD
+REDIS_HOST
+REDIS_PORT
+REDIS_PASSWORD
+```
+
+If you use an external PostgreSQL database, add all five `DB_*` secrets. If you want the deployment to create a local PostgreSQL container, leave all `DB_*` secrets unset.
+
+If you use an external Redis instance, add all three `REDIS_*` secrets. If you want the deployment to create a local Redis container, leave all `REDIS_*` secrets unset.
+
+Put these server-only app secrets in `/home/<EC2_USER>/chatapp/.env` on the EC2 instance:
+
+```bash
+JWT_SECRET=...
+GOOGLE_CLIENT_ID=...
+GOOGLE_SECRET_ID=...
+GOOGLE_REDIRECT_URI=...
+```
+
+Create and secure the file like this, replacing `ubuntu` with your EC2 user:
+
+```bash
+sudo mkdir -p /home/ubuntu/chatapp
+sudo nano /home/ubuntu/chatapp/.env
+sudo chown ubuntu:ubuntu /home/ubuntu/chatapp/.env
+chmod 600 /home/ubuntu/chatapp/.env
+```
+
+For your domain secret, use:
+
+```text
+DOMAIN_NAME=chat.fredmaina.com
+```
+
+Do not use:
+
+```text
+DOMAIN_NAME=https://chat.fredmaina.com
+```
+
+## Updated Expected Outcome
+
+After this work is complete:
+
+- The EC2 instance should serve the app through Nginx.
+- Public traffic should use HTTPS.
+- Nginx should reverse-proxy traffic to `localhost:8080`.
+- Raw-IP requests should be rejected instead of proxied.
+- Certbot should manage SSL certificates.
+- GitHub Actions should deploy the app easily.
+- Running the deployment multiple times should be safe.
+- If external DB credentials are provided, the app should use the external database.
+- If external DB credentials are missing, the deployment should create a local PostgreSQL Docker container.
+- The local PostgreSQL container should persist data using a Docker volume.
+- If external Redis credentials are missing, the deployment should create a local Redis Docker container.
+- Redis should bind only to `127.0.0.1` and use a generated password.
+- The app should automatically receive the correct database environment variables.
+- The app should automatically receive the correct Redis environment variables.

--- a/scripts/check_app_health.sh
+++ b/scripts/check_app_health.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HEALTH_URL="${1:-}"
+REQUIRE_COMPONENTS="${REQUIRE_COMPONENTS:-db,redis}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-24}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
+
+if [[ -z "${HEALTH_URL}" ]]; then
+  echo "ERROR: health URL is required. Example: bash scripts/check_app_health.sh http://localhost:8080/actuator/health" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "ERROR: curl is required for health checks." >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required for health response validation." >&2
+  exit 1
+fi
+
+validate_health_json() {
+  local response_file="$1"
+
+  python3 - "${response_file}" "${REQUIRE_COMPONENTS}" <<'PY'
+import json
+import sys
+
+response_path = sys.argv[1]
+required_components = [item.strip() for item in sys.argv[2].split(",") if item.strip()]
+
+with open(response_path, "r", encoding="utf-8") as fh:
+    payload = json.load(fh)
+
+overall_status = payload.get("status")
+if overall_status != "UP":
+    print(f"Health status is {overall_status!r}, expected 'UP'.")
+    sys.exit(1)
+
+components = payload.get("components") or {}
+missing = []
+unhealthy = []
+
+for component in required_components:
+    component_payload = components.get(component)
+    if not component_payload:
+        missing.append(component)
+        continue
+
+    component_status = component_payload.get("status")
+    if component_status != "UP":
+        unhealthy.append(f"{component}={component_status!r}")
+
+if missing:
+    print("Missing health components: " + ", ".join(missing))
+    sys.exit(1)
+
+if unhealthy:
+    print("Unhealthy health components: " + ", ".join(unhealthy))
+    sys.exit(1)
+
+print("Health check passed: app=UP, " + ", ".join(f"{component}=UP" for component in required_components))
+PY
+}
+
+attempt=1
+response_file="$(mktemp)"
+trap 'rm -f "${response_file}"' EXIT
+
+while [[ "${attempt}" -le "${MAX_ATTEMPTS}" ]]; do
+  http_status="$(curl --silent --show-error --location --max-time 10 --output "${response_file}" --write-out "%{http_code}" "${HEALTH_URL}" || true)"
+
+  if [[ "${http_status}" == "200" ]]; then
+    if validate_health_json "${response_file}"; then
+      exit 0
+    fi
+  else
+    echo "Health check attempt ${attempt}/${MAX_ATTEMPTS} returned HTTP ${http_status} for ${HEALTH_URL}."
+  fi
+
+  if [[ "${attempt}" -lt "${MAX_ATTEMPTS}" ]]; then
+    sleep "${SLEEP_SECONDS}"
+  fi
+
+  attempt=$((attempt + 1))
+done
+
+echo "ERROR: health endpoint did not become healthy: ${HEALTH_URL}" >&2
+exit 1

--- a/scripts/setup_nginx.sh
+++ b/scripts/setup_nginx.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PORT="${APP_PORT:-8080}"
+SITE_NAME="${SITE_NAME:-chatapp}"
+NGINX_AVAILABLE="/etc/nginx/sites-available/${SITE_NAME}.conf"
+NGINX_ENABLED="/etc/nginx/sites-enabled/${SITE_NAME}.conf"
+CERTBOT_WEBROOT="/var/www/certbot"
+
+if [[ -z "${DOMAIN_NAME:-}" ]]; then
+  echo "ERROR: DOMAIN_NAME is required. Example: DOMAIN_NAME=example.com CERTBOT_EMAIL=admin@example.com bash scripts/setup_nginx.sh" >&2
+  exit 1
+fi
+
+if [[ "${DOMAIN_NAME}" == http://* || "${DOMAIN_NAME}" == https://* || "${DOMAIN_NAME}" == */* ]]; then
+  echo "ERROR: DOMAIN_NAME must be a hostname only, for example chat.fredmaina.com. Do not include http:// or https://." >&2
+  exit 1
+fi
+
+if [[ -z "${CERTBOT_EMAIL:-}" ]]; then
+  echo "ERROR: CERTBOT_EMAIL is required. Example: DOMAIN_NAME=example.com CERTBOT_EMAIL=admin@example.com bash scripts/setup_nginx.sh" >&2
+  exit 1
+fi
+
+if ! [[ "${APP_PORT}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: APP_PORT must be a number. Current value: ${APP_PORT}" >&2
+  exit 1
+fi
+
+run_sudo() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+package_installed() {
+  dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q "install ok installed"
+}
+
+install_packages() {
+  local packages_to_install=()
+
+  for package in nginx certbot python3-certbot-nginx; do
+    if ! package_installed "${package}"; then
+      packages_to_install+=("${package}")
+    fi
+  done
+
+  if [[ "${#packages_to_install[@]}" -eq 0 ]]; then
+    echo "Nginx and Certbot packages are already installed."
+    return
+  fi
+
+  echo "Installing missing packages: ${packages_to_install[*]}"
+  run_sudo apt-get update
+  run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "${packages_to_install[@]}"
+}
+
+ensure_site_enabled() {
+  run_sudo mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled "${CERTBOT_WEBROOT}"
+
+  if [[ -L "${NGINX_ENABLED}" ]]; then
+    local current_target
+    current_target="$(readlink "${NGINX_ENABLED}")"
+    if [[ "${current_target}" != "${NGINX_AVAILABLE}" ]]; then
+      echo "Updating enabled site symlink: ${NGINX_ENABLED}"
+      run_sudo ln -sfn "${NGINX_AVAILABLE}" "${NGINX_ENABLED}"
+    fi
+  elif [[ -e "${NGINX_ENABLED}" ]]; then
+    echo "ERROR: ${NGINX_ENABLED} exists and is not a symlink. Move it aside before rerunning this script." >&2
+    exit 1
+  else
+    echo "Enabling Nginx site: ${SITE_NAME}"
+    run_sudo ln -s "${NGINX_AVAILABLE}" "${NGINX_ENABLED}"
+  fi
+}
+
+disable_stock_default_site() {
+  local default_site="/etc/nginx/sites-enabled/default"
+
+  if [[ -L "${default_site}" ]]; then
+    echo "Disabling stock Nginx default site so raw-IP requests use the managed reject server."
+    run_sudo rm -f "${default_site}"
+  fi
+}
+
+write_if_changed() {
+  local target_file="$1"
+  local temp_file
+  temp_file="$(mktemp)"
+  cat > "${temp_file}"
+
+  if run_sudo test -f "${target_file}" && run_sudo cmp -s "${temp_file}" "${target_file}"; then
+    rm -f "${temp_file}"
+    echo "Nginx config is already up to date: ${target_file}"
+    return 1
+  fi
+
+  echo "Writing Nginx config: ${target_file}"
+  run_sudo install -m 0644 "${temp_file}" "${target_file}"
+  rm -f "${temp_file}"
+  return 0
+}
+
+render_http_bootstrap_config() {
+  cat <<EOF
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 444;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${DOMAIN_NAME};
+
+    location /.well-known/acme-challenge/ {
+        root ${CERTBOT_WEBROOT};
+    }
+
+    location / {
+        proxy_pass http://localhost:${APP_PORT};
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+EOF
+}
+
+render_https_config() {
+  cat <<EOF
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 444;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${DOMAIN_NAME};
+
+    location /.well-known/acme-challenge/ {
+        root ${CERTBOT_WEBROOT};
+    }
+
+    location / {
+        return 301 https://\$host\$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
+    server_name _;
+
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 444;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${DOMAIN_NAME};
+
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass http://localhost:${APP_PORT};
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+EOF
+}
+
+test_and_reload_nginx() {
+  echo "Validating Nginx configuration..."
+  run_sudo nginx -t
+
+  echo "Reloading Nginx..."
+  if run_sudo systemctl is-active --quiet nginx; then
+    run_sudo systemctl reload nginx
+  else
+    run_sudo systemctl restart nginx
+  fi
+}
+
+certificate_exists() {
+  run_sudo test -f "/etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem" \
+    && run_sudo test -f "/etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem"
+}
+
+install_packages
+run_sudo systemctl enable nginx
+disable_stock_default_site
+
+if certificate_exists; then
+  echo "SSL certificate already exists for ${DOMAIN_NAME}."
+else
+  echo "SSL certificate not found for ${DOMAIN_NAME}; installing temporary HTTP config for certificate issuance."
+  render_http_bootstrap_config | write_if_changed "${NGINX_AVAILABLE}" || true
+  ensure_site_enabled
+  test_and_reload_nginx
+
+  echo "Requesting SSL certificate for ${DOMAIN_NAME}."
+  run_sudo certbot certonly \
+    --nginx \
+    --non-interactive \
+    --agree-tos \
+    --email "${CERTBOT_EMAIL}" \
+    --domains "${DOMAIN_NAME}" \
+    --keep-until-expiring \
+    --expand
+fi
+
+render_https_config | write_if_changed "${NGINX_AVAILABLE}" || true
+ensure_site_enabled
+test_and_reload_nginx
+
+echo "Renewing certificates when due."
+run_sudo certbot renew --quiet
+
+test_and_reload_nginx
+
+echo "Nginx HTTPS setup complete for ${DOMAIN_NAME}; proxying to localhost:${APP_PORT}."

--- a/scripts/setup_postgres.sh
+++ b/scripts/setup_postgres.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_CONFIG_DIR="${APP_CONFIG_DIR:-/opt/myapp}"
+APP_ENV_FILE="${APP_ENV_FILE:-${APP_CONFIG_DIR}/.env}"
+APP_POSTGRES_CONTAINER="${APP_POSTGRES_CONTAINER:-myapp-postgres}"
+APP_POSTGRES_VOLUME="${APP_POSTGRES_VOLUME:-myapp-postgres-data}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:16-alpine}"
+DB_HOST="${DB_HOST:-127.0.0.1}"
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="${DB_NAME:-myapp}"
+DB_USERNAME="${DB_USERNAME:-myapp_user}"
+
+run_sudo() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+package_installed() {
+  dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q "install ok installed"
+}
+
+install_docker_if_missing() {
+  if command -v docker >/dev/null 2>&1; then
+    echo "Docker is already installed."
+    return
+  fi
+
+  echo "Installing Docker..."
+  run_sudo apt-get update
+  run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
+}
+
+ensure_docker_running() {
+  run_sudo systemctl enable docker
+  if ! run_sudo systemctl is-active --quiet docker; then
+    run_sudo systemctl start docker
+  fi
+}
+
+read_existing_env_value() {
+  local key="$1"
+
+  if run_sudo test -f "${APP_ENV_FILE}"; then
+    run_sudo awk -F= -v key="${key}" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "${APP_ENV_FILE}"
+  fi
+}
+
+ensure_db_password() {
+  local existing_password
+  existing_password="$(read_existing_env_value DB_PASSWORD || true)"
+
+  if [[ -n "${DB_PASSWORD:-}" ]]; then
+    echo "${DB_PASSWORD}"
+  elif [[ -n "${existing_password}" ]]; then
+    echo "${existing_password}"
+  else
+    openssl rand -hex 32
+  fi
+}
+
+write_env_file() {
+  local db_password="$1"
+  local temp_file
+  temp_file="$(mktemp)"
+
+  cat > "${temp_file}" <<EOF
+DB_HOST=${DB_HOST}
+DB_PORT=${DB_PORT}
+DB_NAME=${DB_NAME}
+DB_USERNAME=${DB_USERNAME}
+DB_PASSWORD=${db_password}
+SPRING_DATASOURCE_URL=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+SPRING_DATASOURCE_USERNAME=${DB_USERNAME}
+SPRING_DATASOURCE_PASSWORD=${db_password}
+EOF
+
+  run_sudo mkdir -p "${APP_CONFIG_DIR}"
+
+  if run_sudo test -f "${APP_ENV_FILE}" && run_sudo cmp -s "${temp_file}" "${APP_ENV_FILE}"; then
+    rm -f "${temp_file}"
+    echo "Database environment file is already up to date: ${APP_ENV_FILE}"
+    run_sudo chmod 600 "${APP_ENV_FILE}"
+    return
+  fi
+
+  echo "Writing database environment file: ${APP_ENV_FILE}"
+  run_sudo install -m 0600 "${temp_file}" "${APP_ENV_FILE}"
+  rm -f "${temp_file}"
+}
+
+ensure_volume() {
+  if run_sudo docker volume inspect "${APP_POSTGRES_VOLUME}" >/dev/null 2>&1; then
+    echo "PostgreSQL volume already exists: ${APP_POSTGRES_VOLUME}"
+  else
+    echo "Creating PostgreSQL volume: ${APP_POSTGRES_VOLUME}"
+    run_sudo docker volume create "${APP_POSTGRES_VOLUME}" >/dev/null
+  fi
+}
+
+container_exists() {
+  run_sudo docker inspect "${APP_POSTGRES_CONTAINER}" >/dev/null 2>&1
+}
+
+container_running() {
+  [[ "$(run_sudo docker inspect -f '{{.State.Running}}' "${APP_POSTGRES_CONTAINER}" 2>/dev/null || true)" == "true" ]]
+}
+
+ensure_container() {
+  local db_password="$1"
+
+  if container_exists; then
+    echo "PostgreSQL container already exists: ${APP_POSTGRES_CONTAINER}"
+    if container_running; then
+      echo "PostgreSQL container is already running."
+    else
+      echo "Starting existing PostgreSQL container."
+      run_sudo docker start "${APP_POSTGRES_CONTAINER}" >/dev/null
+    fi
+    return
+  fi
+
+  echo "Creating PostgreSQL container: ${APP_POSTGRES_CONTAINER}"
+  run_sudo docker run -d \
+    --name "${APP_POSTGRES_CONTAINER}" \
+    --restart unless-stopped \
+    -e POSTGRES_DB="${DB_NAME}" \
+    -e POSTGRES_USER="${DB_USERNAME}" \
+    -e POSTGRES_PASSWORD="${db_password}" \
+    -p "127.0.0.1:${DB_PORT}:5432" \
+    -v "${APP_POSTGRES_VOLUME}:/var/lib/postgresql/data" \
+    "${POSTGRES_IMAGE}" >/dev/null
+}
+
+if ! package_installed openssl; then
+  run_sudo apt-get update
+  run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y openssl
+fi
+
+DB_PASSWORD="$(ensure_db_password)"
+
+install_docker_if_missing
+ensure_docker_running
+ensure_volume
+write_env_file "${DB_PASSWORD}"
+ensure_container "${DB_PASSWORD}"
+
+echo "Local PostgreSQL setup complete. Credentials are stored in ${APP_ENV_FILE}."

--- a/scripts/setup_redis.sh
+++ b/scripts/setup_redis.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_CONFIG_DIR="${APP_CONFIG_DIR:-/opt/myapp}"
+REDIS_ENV_FILE="${REDIS_ENV_FILE:-${APP_CONFIG_DIR}/redis.env}"
+APP_REDIS_CONTAINER="${APP_REDIS_CONTAINER:-myapp-redis}"
+APP_REDIS_VOLUME="${APP_REDIS_VOLUME:-myapp-redis-data}"
+REDIS_IMAGE="${REDIS_IMAGE:-redis:7-alpine}"
+REDIS_HOST="${REDIS_HOST:-127.0.0.1}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+
+run_sudo() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+package_installed() {
+  dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q "install ok installed"
+}
+
+install_docker_if_missing() {
+  if command -v docker >/dev/null 2>&1; then
+    echo "Docker is already installed."
+    return
+  fi
+
+  echo "Installing Docker..."
+  run_sudo apt-get update
+  run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
+}
+
+ensure_docker_running() {
+  run_sudo systemctl enable docker
+  if ! run_sudo systemctl is-active --quiet docker; then
+    run_sudo systemctl start docker
+  fi
+}
+
+read_existing_env_value() {
+  local key="$1"
+
+  if run_sudo test -f "${REDIS_ENV_FILE}"; then
+    run_sudo awk -F= -v key="${key}" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "${REDIS_ENV_FILE}"
+  fi
+}
+
+ensure_redis_password() {
+  local existing_password
+  existing_password="$(read_existing_env_value REDIS_PASSWORD || true)"
+
+  if [[ -n "${REDIS_PASSWORD:-}" ]]; then
+    echo "${REDIS_PASSWORD}"
+  elif [[ -n "${existing_password}" ]]; then
+    echo "${existing_password}"
+  else
+    openssl rand -hex 32
+  fi
+}
+
+write_env_file() {
+  local redis_password="$1"
+  local temp_file
+  temp_file="$(mktemp)"
+
+  cat > "${temp_file}" <<EOF
+REDIS_HOST=${REDIS_HOST}
+REDIS_PORT=${REDIS_PORT}
+REDIS_PASSWORD=${redis_password}
+EOF
+
+  run_sudo mkdir -p "${APP_CONFIG_DIR}"
+
+  if run_sudo test -f "${REDIS_ENV_FILE}" && run_sudo cmp -s "${temp_file}" "${REDIS_ENV_FILE}"; then
+    rm -f "${temp_file}"
+    echo "Redis environment file is already up to date: ${REDIS_ENV_FILE}"
+    run_sudo chmod 600 "${REDIS_ENV_FILE}"
+    return
+  fi
+
+  echo "Writing Redis environment file: ${REDIS_ENV_FILE}"
+  run_sudo install -m 0600 "${temp_file}" "${REDIS_ENV_FILE}"
+  rm -f "${temp_file}"
+}
+
+ensure_volume() {
+  if run_sudo docker volume inspect "${APP_REDIS_VOLUME}" >/dev/null 2>&1; then
+    echo "Redis volume already exists: ${APP_REDIS_VOLUME}"
+  else
+    echo "Creating Redis volume: ${APP_REDIS_VOLUME}"
+    run_sudo docker volume create "${APP_REDIS_VOLUME}" >/dev/null
+  fi
+}
+
+container_exists() {
+  run_sudo docker inspect "${APP_REDIS_CONTAINER}" >/dev/null 2>&1
+}
+
+container_running() {
+  [[ "$(run_sudo docker inspect -f '{{.State.Running}}' "${APP_REDIS_CONTAINER}" 2>/dev/null || true)" == "true" ]]
+}
+
+ensure_container() {
+  local redis_password="$1"
+
+  if container_exists; then
+    echo "Redis container already exists: ${APP_REDIS_CONTAINER}"
+    if container_running; then
+      echo "Redis container is already running."
+    else
+      echo "Starting existing Redis container."
+      run_sudo docker start "${APP_REDIS_CONTAINER}" >/dev/null
+    fi
+    return
+  fi
+
+  echo "Creating Redis container: ${APP_REDIS_CONTAINER}"
+  run_sudo docker run -d \
+    --name "${APP_REDIS_CONTAINER}" \
+    --restart unless-stopped \
+    -p "127.0.0.1:${REDIS_PORT}:6379" \
+    -v "${APP_REDIS_VOLUME}:/data" \
+    "${REDIS_IMAGE}" \
+    redis-server --appendonly yes --requirepass "${redis_password}" >/dev/null
+}
+
+if ! package_installed openssl; then
+  run_sudo apt-get update
+  run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y openssl
+fi
+
+REDIS_PASSWORD="$(ensure_redis_password)"
+
+install_docker_if_missing
+ensure_docker_running
+ensure_volume
+write_env_file "${REDIS_PASSWORD}"
+ensure_container "${REDIS_PASSWORD}"
+
+echo "Local Redis setup complete. Credentials are stored in ${REDIS_ENV_FILE}."

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,9 @@ spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+spring.flyway.enabled=true
+spring.jpa.hibernate.ddl-auto=validate
+
 
 jwt.secret=${JWT_SECRET}
 jwt.expiration=86400000
@@ -63,7 +66,4 @@ spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 spring.data.redis.password=${REDIS_PASSWORD}
 
-spring.data.redis.url=redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/0
-logging.level.org.springframework.core.env=DEBUG
-
-
+logging.level.org.springframework.core.env=INFO


### PR DESCRIPTION
## Summary
- add idempotent EC2 setup scripts for Nginx/HTTPS, PostgreSQL, Redis, and actuator health checks
- update GitHub Actions deployment to configure local/external DB and Redis, validate env files, and gate deploy success on local/public health checks
- document required secrets, server-only env files, troubleshooting, and deployment assumptions

## Validation
- bash -n scripts/setup_nginx.sh scripts/setup_postgres.sh scripts/setup_redis.sh scripts/check_app_health.sh
- extracted deployment SSH script passes bash -n
- ./mvnw -q clean package -DskipTests