### PR TITLE
Address deployment review feedback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,8 @@ on:
 env:
   APP_NAME: chatapp
   APP_DIR: /home/${{ secrets.EC2_USER }}/chatapp
-  APP_PORT: ${{ secrets.APP_PORT || '8080' }}
+  APP_PORT: '8080'
+  SSH_PRIVATE_KEY: ${{ secrets.EC2_SSH_PRIVATE_KEY || secrets.EC2_SSH_KEY }}
 
 jobs:
   build-and-deploy:
@@ -38,12 +39,33 @@ jobs:
           cp scripts/setup_redis.sh deploy/setup_redis.sh
           cp scripts/check_app_health.sh deploy/check_app_health.sh
 
+      - name: Validate deployment secrets
+        env:
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+          EC2_USER: ${{ secrets.EC2_USER }}
+          DOMAIN_NAME: ${{ secrets.DOMAIN_NAME }}
+          CERTBOT_EMAIL: ${{ secrets.CERTBOT_EMAIL }}
+        run: |
+          missing=()
+
+          [[ -n "${EC2_HOST}" ]] || missing+=("EC2_HOST")
+          [[ -n "${EC2_USER}" ]] || missing+=("EC2_USER")
+          [[ -n "${SSH_PRIVATE_KEY}" ]] || missing+=("EC2_SSH_PRIVATE_KEY")
+          [[ -n "${DOMAIN_NAME}" ]] || missing+=("DOMAIN_NAME")
+          [[ -n "${CERTBOT_EMAIL}" ]] || missing+=("CERTBOT_EMAIL")
+
+          if [[ "${#missing[@]}" -gt 0 ]]; then
+            echo "Missing required GitHub Secrets: ${missing[*]}"
+            echo "Set EC2_SSH_PRIVATE_KEY to the full private key, including BEGIN/END lines."
+            exit 1
+          fi
+
       - name: Copy deployment bundle to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          key: ${{ env.SSH_PRIVATE_KEY }}
           source: deploy/*
           target: ${{ env.APP_DIR }}
           strip_components: 1
@@ -70,7 +92,7 @@ jobs:
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          key: ${{ env.SSH_PRIVATE_KEY }}
           envs: APP_DIR,APP_NAME,APP_PORT,APP_CONFIG_DIR,APP_ENV_FILE,REDIS_ENV_FILE,DOMAIN_NAME,CERTBOT_EMAIL,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,REDIS_HOST,REDIS_PORT,REDIS_PASSWORD
           script_stop: true
           script: |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,7 +32,7 @@ Configure these secrets in the GitHub repository before using the deployment wor
 | `EC2_SSH_PRIVATE_KEY` | Private SSH key that can log in as `EC2_USER`. Do not commit this key. |
 | `DOMAIN_NAME` | Public domain that points to the EC2 instance, for example `api.example.com`. Use the hostname only; do not include `http://` or `https://`. |
 | `CERTBOT_EMAIL` | Email used by Certbot for Let's Encrypt registration and renewal notices. |
-| `APP_PORT` | Optional local app port. Use `8080`; if omitted in the workflow, it defaults to `8080`. |
+| `APP_PORT` | Not required. The workflow pins the app to `8080` so Spring Boot and actuator health checks use the same port. |
 
 Optional database secrets:
 
@@ -74,6 +74,16 @@ GOOGLE_REDIRECT_URI=...
 Deployment validates this file before restarting the app. If any required key is missing or empty, the workflow fails before starting the service and prints only the missing key names, not secret values.
 
 Do not commit private keys, database passwords, JWT secrets, OAuth secrets, or Redis passwords.
+
+`EC2_SSH_PRIVATE_KEY` must contain the full private key, including the header and footer lines:
+
+```text
+-----BEGIN OPENSSH PRIVATE KEY-----
+...
+-----END OPENSSH PRIVATE KEY-----
+```
+
+The workflow also accepts the old secret name `EC2_SSH_KEY` as a fallback, but `EC2_SSH_PRIVATE_KEY` is the preferred name.
 
 Database connection values are written by deployment to:
 
@@ -187,6 +197,7 @@ Local PostgreSQL mode is used when any required database secret is missing. In t
 - Generates a secure password with `openssl rand -hex 32` when no existing local password is present.
 - Stores local DB config in `/opt/myapp/.env`.
 - Starts the existing container if it is stopped.
+- Waits for PostgreSQL readiness with `pg_isready` before the deployment starts the app.
 
 The local PostgreSQL volume preserves database data across deployments and container restarts.
 
@@ -220,7 +231,9 @@ Local Redis mode is used when any required Redis secret is missing. In this mode
 - Binds Redis to `127.0.0.1:6379`.
 - Generates a secure password with `openssl rand -hex 32` when no existing local password is present.
 - Stores local Redis config in `/opt/myapp/redis.env`.
+- Stores Redis server auth config in `/opt/myapp/redis.conf` and mounts it into the container, so the password is not placed in the Docker command line.
 - Starts the existing container if it is stopped.
+- Waits for Redis readiness with `redis-cli ping` before the deployment starts the app.
 
 Run the local Redis setup manually:
 
@@ -264,6 +277,7 @@ The Redis setup script is also safe to run during every deployment:
 - It reuses existing credentials from `/opt/myapp/redis.env`.
 - It does not regenerate the local Redis password when one already exists.
 - It binds Redis to `127.0.0.1`, not a public interface.
+- It recreates only the Redis container, not the data volume, if an older container exposed the password in Docker command arguments.
 
 Flyway migrations run automatically when the Spring Boot app starts. Hibernate schema validation is enabled with `spring.jpa.hibernate.ddl-auto=validate`, so the app fails startup if the schema created by migrations no longer matches the entity models.
 
@@ -459,7 +473,6 @@ CERTBOT_EMAIL
 Optional GitHub repository secrets:
 
 ```text
-APP_PORT
 DB_HOST
 DB_PORT
 DB_NAME

--- a/scripts/setup_postgres.sh
+++ b/scripts/setup_postgres.sh
@@ -135,6 +135,26 @@ ensure_container() {
     "${POSTGRES_IMAGE}" >/dev/null
 }
 
+wait_for_postgres() {
+  local max_attempts="${POSTGRES_READY_MAX_ATTEMPTS:-30}"
+  local sleep_seconds="${POSTGRES_READY_SLEEP_SECONDS:-2}"
+  local attempt=1
+
+  echo "Waiting for PostgreSQL to accept connections..."
+  while [[ "${attempt}" -le "${max_attempts}" ]]; do
+    if run_sudo docker exec "${APP_POSTGRES_CONTAINER}" pg_isready -U "${DB_USERNAME}" -d "${DB_NAME}" >/dev/null 2>&1; then
+      echo "PostgreSQL is ready."
+      return
+    fi
+
+    sleep "${sleep_seconds}"
+    attempt=$((attempt + 1))
+  done
+
+  echo "ERROR: PostgreSQL did not become ready in time." >&2
+  exit 1
+}
+
 if ! package_installed openssl; then
   run_sudo apt-get update
   run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y openssl
@@ -147,5 +167,6 @@ ensure_docker_running
 ensure_volume
 write_env_file "${DB_PASSWORD}"
 ensure_container "${DB_PASSWORD}"
+wait_for_postgres
 
 echo "Local PostgreSQL setup complete. Credentials are stored in ${APP_ENV_FILE}."

--- a/scripts/setup_redis.sh
+++ b/scripts/setup_redis.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 APP_CONFIG_DIR="${APP_CONFIG_DIR:-/opt/myapp}"
 REDIS_ENV_FILE="${REDIS_ENV_FILE:-${APP_CONFIG_DIR}/redis.env}"
+REDIS_CONFIG_FILE="${REDIS_CONFIG_FILE:-${APP_CONFIG_DIR}/redis.conf}"
 APP_REDIS_CONTAINER="${APP_REDIS_CONTAINER:-myapp-redis}"
 APP_REDIS_VOLUME="${APP_REDIS_VOLUME:-myapp-redis-data}"
 REDIS_IMAGE="${REDIS_IMAGE:-redis:7-alpine}"
@@ -85,6 +86,33 @@ EOF
   rm -f "${temp_file}"
 }
 
+write_redis_config() {
+  local redis_password="$1"
+  local temp_file
+  temp_file="$(mktemp)"
+
+  cat > "${temp_file}" <<EOF
+appendonly yes
+protected-mode yes
+requirepass ${redis_password}
+EOF
+
+  run_sudo mkdir -p "${APP_CONFIG_DIR}"
+
+  if run_sudo test -f "${REDIS_CONFIG_FILE}" && run_sudo cmp -s "${temp_file}" "${REDIS_CONFIG_FILE}"; then
+    rm -f "${temp_file}"
+    echo "Redis config is already up to date: ${REDIS_CONFIG_FILE}"
+    run_sudo chmod 600 "${REDIS_CONFIG_FILE}"
+    run_sudo chown 999:999 "${REDIS_CONFIG_FILE}"
+    return
+  fi
+
+  echo "Writing Redis config: ${REDIS_CONFIG_FILE}"
+  run_sudo install -m 0600 "${temp_file}" "${REDIS_CONFIG_FILE}"
+  run_sudo chown 999:999 "${REDIS_CONFIG_FILE}"
+  rm -f "${temp_file}"
+}
+
 ensure_volume() {
   if run_sudo docker volume inspect "${APP_REDIS_VOLUME}" >/dev/null 2>&1; then
     echo "Redis volume already exists: ${APP_REDIS_VOLUME}"
@@ -102,11 +130,44 @@ container_running() {
   [[ "$(run_sudo docker inspect -f '{{.State.Running}}' "${APP_REDIS_CONTAINER}" 2>/dev/null || true)" == "true" ]]
 }
 
-ensure_container() {
-  local redis_password="$1"
+container_uses_inline_password() {
+  run_sudo docker inspect -f '{{json .Config.Cmd}}' "${APP_REDIS_CONTAINER}" 2>/dev/null | grep -q -- "--requirepass"
+}
 
+container_uses_managed_config() {
+  run_sudo docker inspect -f '{{range .Mounts}}{{println .Destination}}{{end}}' "${APP_REDIS_CONTAINER}" 2>/dev/null \
+    | grep -qx "/usr/local/etc/redis/redis.conf"
+}
+
+container_needs_recreate() {
+  container_uses_inline_password || ! container_uses_managed_config
+}
+
+recreate_container_without_losing_data() {
+  echo "Recreating Redis container to use the managed config file without deleting the data volume."
+  if container_running; then
+    run_sudo docker stop "${APP_REDIS_CONTAINER}" >/dev/null
+  fi
+  run_sudo docker rm "${APP_REDIS_CONTAINER}" >/dev/null
+}
+
+ensure_container() {
   if container_exists; then
     echo "Redis container already exists: ${APP_REDIS_CONTAINER}"
+    if container_needs_recreate; then
+      recreate_container_without_losing_data
+    else
+      if container_running; then
+        echo "Redis container is already running."
+      else
+        echo "Starting existing Redis container."
+        run_sudo docker start "${APP_REDIS_CONTAINER}" >/dev/null
+      fi
+      return
+    fi
+  fi
+
+  if container_exists; then
     if container_running; then
       echo "Redis container is already running."
     else
@@ -122,8 +183,30 @@ ensure_container() {
     --restart unless-stopped \
     -p "127.0.0.1:${REDIS_PORT}:6379" \
     -v "${APP_REDIS_VOLUME}:/data" \
+    -v "${REDIS_CONFIG_FILE}:/usr/local/etc/redis/redis.conf:ro" \
     "${REDIS_IMAGE}" \
-    redis-server --appendonly yes --requirepass "${redis_password}" >/dev/null
+    redis-server /usr/local/etc/redis/redis.conf >/dev/null
+}
+
+wait_for_redis() {
+  local redis_password="$1"
+  local max_attempts="${REDIS_READY_MAX_ATTEMPTS:-30}"
+  local sleep_seconds="${REDIS_READY_SLEEP_SECONDS:-2}"
+  local attempt=1
+
+  echo "Waiting for Redis to accept connections..."
+  while [[ "${attempt}" -le "${max_attempts}" ]]; do
+    if run_sudo docker exec -e REDISCLI_AUTH="${redis_password}" "${APP_REDIS_CONTAINER}" redis-cli ping 2>/dev/null | grep -q "PONG"; then
+      echo "Redis is ready."
+      return
+    fi
+
+    sleep "${sleep_seconds}"
+    attempt=$((attempt + 1))
+  done
+
+  echo "ERROR: Redis did not become ready in time." >&2
+  exit 1
 }
 
 if ! package_installed openssl; then
@@ -137,6 +220,8 @@ install_docker_if_missing
 ensure_docker_running
 ensure_volume
 write_env_file "${REDIS_PASSWORD}"
-ensure_container "${REDIS_PASSWORD}"
+write_redis_config "${REDIS_PASSWORD}"
+ensure_container
+wait_for_redis "${REDIS_PASSWORD}"
 
 echo "Local Redis setup complete. Credentials are stored in ${REDIS_ENV_FILE}."


### PR DESCRIPTION
## Summary
- pin deployment APP_PORT to 8080 to match the app and actuator management port
- wait for local PostgreSQL readiness before starting the app
- move local Redis auth into a mounted redis.conf, recreate only the Redis container when needed, and wait for Redis readiness
- update deployment docs for fixed app port and readiness behavior

## Validation
- bash -n scripts/setup_nginx.sh scripts/setup_postgres.sh scripts/setup_redis.sh scripts/check_app_health.sh
- extracted deployment SSH script passes bash -n
- ./mvnw -q clean package -DskipTests